### PR TITLE
Add `as` prop for specifying element/component to use

### DIFF
--- a/__snapshots__/index.spec.js.snap
+++ b/__snapshots__/index.spec.js.snap
@@ -153,6 +153,277 @@ exports[`TeX configuring KaTeX via props.settings 1`] = `
 </div>
 `;
 
+exports[`TeX customizing block element type via props.as & props.block 1`] = `
+<div>
+  <figcaption
+    data-testid="wrapper"
+    style="display: block;"
+  >
+    <span
+      class="katex-display"
+    >
+      <span
+        class="katex"
+      >
+        <span
+          class="katex-mathml"
+        >
+          <math>
+            <semantics>
+              <mrow>
+                <munderover>
+                  <mo>
+                    ∑
+                  </mo>
+                  <mn>
+                    0
+                  </mn>
+                  <mi
+                    mathvariant="normal"
+                  >
+                    ∞
+                  </mi>
+                </munderover>
+              </mrow>
+              <annotation
+                encoding="application/x-tex"
+              >
+                \\sum_0^\\infty
+              </annotation>
+            </semantics>
+          </math>
+        </span>
+        <span
+          aria-hidden="true"
+          class="katex-html"
+        >
+          <span
+            class="base"
+          >
+            <span
+              class="strut"
+              style="height:2.9185100000000004em;vertical-align:-1.267113em;"
+            />
+            <span
+              class="mop op-limits"
+            >
+              <span
+                class="vlist-t vlist-t2"
+              >
+                <span
+                  class="vlist-r"
+                >
+                  <span
+                    class="vlist"
+                    style="height:1.6513970000000002em;"
+                  >
+                    <span
+                      style="top:-1.882887em;margin-left:0em;"
+                    >
+                      <span
+                        class="pstrut"
+                        style="height:3.05em;"
+                      />
+                      <span
+                        class="sizing reset-size6 size3 mtight"
+                      >
+                        <span
+                          class="mord mtight"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </span>
+                    <span
+                      style="top:-3.050005em;"
+                    >
+                      <span
+                        class="pstrut"
+                        style="height:3.05em;"
+                      />
+                      <span>
+                        <span
+                          class="mop op-symbol large-op"
+                        >
+                          ∑
+                        </span>
+                      </span>
+                    </span>
+                    <span
+                      style="top:-4.3000050000000005em;margin-left:0em;"
+                    >
+                      <span
+                        class="pstrut"
+                        style="height:3.05em;"
+                      />
+                      <span
+                        class="sizing reset-size6 size3 mtight"
+                      >
+                        <span
+                          class="mord mtight"
+                        >
+                          ∞
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span
+                    class="vlist-s"
+                  >
+                    ​
+                  </span>
+                </span>
+                <span
+                  class="vlist-r"
+                >
+                  <span
+                    class="vlist"
+                    style="height:1.267113em;"
+                  >
+                    <span />
+                  </span>
+                </span>
+              </span>
+            </span>
+          </span>
+        </span>
+      </span>
+    </span>
+  </figcaption>
+</div>
+`;
+
+exports[`TeX customizing element type via props.as 1`] = `
+<div>
+  <var
+    data-testid="wrapper"
+    style="display: inline;"
+  >
+    <span
+      class="katex"
+    >
+      <span
+        class="katex-mathml"
+      >
+        <math>
+          <semantics>
+            <mrow>
+              <msubsup>
+                <mo>
+                  ∑
+                </mo>
+                <mn>
+                  0
+                </mn>
+                <mi
+                  mathvariant="normal"
+                >
+                  ∞
+                </mi>
+              </msubsup>
+            </mrow>
+            <annotation
+              encoding="application/x-tex"
+            >
+              \\sum_0^\\infty
+            </annotation>
+          </semantics>
+        </math>
+      </span>
+      <span
+        aria-hidden="true"
+        class="katex-html"
+      >
+        <span
+          class="base"
+        >
+          <span
+            class="strut"
+            style="height:1.104002em;vertical-align:-0.29971000000000003em;"
+          />
+          <span
+            class="mop"
+          >
+            <span
+              class="mop op-symbol small-op"
+              style="position:relative;top:-0.0000050000000000050004em;"
+            >
+              ∑
+            </span>
+            <span
+              class="msupsub"
+            >
+              <span
+                class="vlist-t vlist-t2"
+              >
+                <span
+                  class="vlist-r"
+                >
+                  <span
+                    class="vlist"
+                    style="height:0.804292em;"
+                  >
+                    <span
+                      style="top:-2.40029em;margin-left:0em;margin-right:0.05em;"
+                    >
+                      <span
+                        class="pstrut"
+                        style="height:2.7em;"
+                      />
+                      <span
+                        class="sizing reset-size6 size3 mtight"
+                      >
+                        <span
+                          class="mord mtight"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </span>
+                    <span
+                      style="top:-3.2029em;margin-right:0.05em;"
+                    >
+                      <span
+                        class="pstrut"
+                        style="height:2.7em;"
+                      />
+                      <span
+                        class="sizing reset-size6 size3 mtight"
+                      >
+                        <span
+                          class="mord mtight"
+                        >
+                          ∞
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span
+                    class="vlist-s"
+                  >
+                    ​
+                  </span>
+                </span>
+                <span
+                  class="vlist-r"
+                >
+                  <span
+                    class="vlist"
+                    style="height:0.29971000000000003em;"
+                  >
+                    <span />
+                  </span>
+                </span>
+              </span>
+            </span>
+          </span>
+        </span>
+      </span>
+    </span>
+  </var>
+</div>
+`;
+
 exports[`TeX error handling error is caused while parsing math expression 1`] = `
 <div>
   <span>
@@ -778,6 +1049,123 @@ exports[`TeX passing through other props style 1`] = `
       </span>
     </span>
   </span>
+</div>
+`;
+
+exports[`TeX passing through other props user style overwriting display style added by props.as 1`] = `
+<div>
+  <figcaption
+    style="display: inline;"
+  >
+    <span
+      class="katex-display"
+    >
+      <span
+        class="katex"
+      >
+        <span
+          class="katex-mathml"
+        >
+          <math>
+            <semantics>
+              <mrow>
+                <mn>
+                  1
+                </mn>
+                <mo>
+                  +
+                </mo>
+                <mn>
+                  2
+                </mn>
+                <mo>
+                  =
+                </mo>
+                <mn>
+                  3
+                </mn>
+              </mrow>
+              <annotation
+                encoding="application/x-tex"
+              >
+                1 + 2 = 3
+              </annotation>
+            </semantics>
+          </math>
+        </span>
+        <span
+          aria-hidden="true"
+          class="katex-html"
+        >
+          <span
+            class="base"
+          >
+            <span
+              class="strut"
+              style="height:0.72777em;vertical-align:-0.08333em;"
+            />
+            <span
+              class="mord"
+            >
+              1
+            </span>
+            <span
+              class="mspace"
+              style="margin-right:0.2222222222222222em;"
+            />
+            <span
+              class="mbin"
+            >
+              +
+            </span>
+            <span
+              class="mspace"
+              style="margin-right:0.2222222222222222em;"
+            />
+          </span>
+          <span
+            class="base"
+          >
+            <span
+              class="strut"
+              style="height:0.64444em;vertical-align:0em;"
+            />
+            <span
+              class="mord"
+            >
+              2
+            </span>
+            <span
+              class="mspace"
+              style="margin-right:0.2777777777777778em;"
+            />
+            <span
+              class="mrel"
+            >
+              =
+            </span>
+            <span
+              class="mspace"
+              style="margin-right:0.2777777777777778em;"
+            />
+          </span>
+          <span
+            class="base"
+          >
+            <span
+              class="strut"
+              style="height:0.64444em;vertical-align:0em;"
+            />
+            <span
+              class="mord"
+            >
+              3
+            </span>
+          </span>
+        </span>
+      </span>
+    </span>
+  </figcaption>
 </div>
 `;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { KatexOptions, ParseError } from 'katex';
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, ElementType, CSSProperties } from 'react';
 
 declare module '@matejmazur/react-katex' {
   export interface TeXProps {
@@ -9,6 +9,8 @@ declare module '@matejmazur/react-katex' {
     errorColor: string;
     renderError: (error: ParseError | TypeError) => ReactNode;
     settings: KatexOptions;
+    as: ElementType;
+    style: CSSProperties;
   }
 
   const TeX: FC<TeXProps>;

--- a/index.js
+++ b/index.js
@@ -4,10 +4,23 @@ import KaTeX from 'katex';
 
 function TeX(props) {
   const otherProps = omit(
-    ['children', 'math', 'block', 'errorColor', 'renderError', 'settings'],
+    [
+      'children',
+      'math',
+      'block',
+      'errorColor',
+      'renderError',
+      'settings',
+      'as',
+      'style'
+    ],
     props
   );
-  const Component = props.block ? 'div' : 'span';
+  const Component = props.as || (props.block ? 'div' : 'span');
+  const displayStyle = props.as
+    ? { display: props.block ? 'block' : 'inline' }
+    : null;
+  const style = Object.assign({}, displayStyle, props.style);
   const content = props.children || props.math;
 
   try {
@@ -26,7 +39,11 @@ function TeX(props) {
     );
 
     return (
-      <Component {...otherProps} dangerouslySetInnerHTML={{ __html: html }} />
+      <Component
+        {...otherProps}
+        style={style}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
     );
   } catch (error) {
     if (error instanceof KaTeX.ParseError || error instanceof TypeError) {
@@ -35,6 +52,7 @@ function TeX(props) {
       ) : (
         <Component
           {...otherProps}
+          style={style}
           dangerouslySetInnerHTML={{ __html: error.message }}
         />
       );
@@ -50,7 +68,9 @@ TeX.propTypes = {
   block: PropTypes.bool,
   errorColor: PropTypes.string,
   renderError: PropTypes.func,
-  settings: PropTypes.object
+  settings: PropTypes.object,
+  as: PropTypes.elementType,
+  style: PropTypes.object
 };
 
 export default memo(TeX);

--- a/index.spec.js
+++ b/index.spec.js
@@ -28,6 +28,26 @@ describe('TeX', () => {
     expect($.getByTestId('wrapper').tagName).toBe('DIV');
   });
 
+  test('customizing element type via props.as', () => {
+    const $ = render(
+      <TeX data-testid="wrapper" as="var">
+        \sum_0^\infty
+      </TeX>
+    );
+    expect($.getByTestId('wrapper').tagName).toBe('VAR');
+    expect($.container).toMatchSnapshot();
+  });
+
+  test('customizing block element type via props.as & props.block', () => {
+    const $ = render(
+      <TeX data-testid="wrapper" as="figcaption" block>
+        \sum_0^\infty
+      </TeX>
+    );
+    expect($.getByTestId('wrapper').tagName).toBe('FIGCAPTION');
+    expect($.container).toMatchSnapshot();
+  });
+
   test('configuring KaTeX via props.settings', () => {
     const $ = render(
       <TeX settings={{ macros: { '*': 'cdot' } }}>y = k * x + c</TeX>
@@ -113,6 +133,15 @@ describe('TeX', () => {
   describe('passing through other props', () => {
     test('style', () => {
       const $ = render(<TeX style={{ background: 'blue' }}>1 + 2 = 3</TeX>);
+      expect($.container).toMatchSnapshot();
+    });
+
+    test('user style overwriting display style added by props.as', () => {
+      const $ = render(
+        <TeX style={{ display: 'inline' }} as="figcaption" block>
+          1 + 2 = 3
+        </TeX>
+      );
       expect($.container).toMatchSnapshot();
     });
 


### PR DESCRIPTION
Hello!

I found myself wanting to use a different semantic HTML element than `<div>` or `<span>` for my KaTeX element (`<label>`, specifically, in my situation, since I'm wanting to label a chart with it), so I propose adding a new prop called `as` for specifying what kind of HTML element (or React component) you want the KaTeX to appear as.

I modeled it after how [React Bootstrap](https://react-bootstrap.github.io/) uses an `as` prop throughout all their components (here's [an example](https://github.com/react-bootstrap/react-bootstrap/blob/dca61bddb3d6a44b017babc77999af860a15e5f2/src/Container.tsx#L36-L58) and [its documentation](https://react-bootstrap.github.io/layout/grid/#container-props) from their `Container` component), giving it `PropTypes.elementType` and type `React.ElementType`.

I also added functionality to explicitly add an inline CSS style of either `display: block;` or `display: inline;` to the element whenever `as` is used, since the document may not be able to infer it from the use of either `<div>` or `<span>`. This required removing `style` from `otherProps` as well, to merge any user-entered styles with the new display style. I gave the `style` prop `PropTypes.object` and type `React.CSSProperties` (the latter because that seems to be what [`@types/react` prescribes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/27cb7a9e89ff0bd88114d10ecc50dccd7f8ae13b/types/react/index.d.ts#L1754)).

All 16 current tests are passing with these changes, and I'd be happy to write additional tests for this new functionality and add them to this PR—I just figured I'd ask first before taking the time.