### PR TITLE
Fix double slashes in README which yield an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Display math in the middle of the text.
 
 ```jsx
 ReactDOM.render(
-  <TeX math="\\int_0^\\infty x^2 dx" />,
+  <TeX math="\int_0^\infty x^2 dx" />,
   document.getElementById('math')
 );
 
@@ -68,7 +68,7 @@ Display math in a separated block, with larger font and symbols.
 
 ```jsx
 ReactDOM.render(
-  <TeX math="\\int_0^\\infty x^2 dx" block />,
+  <TeX math="\int_0^\infty x^2 dx" block />,
   document.getElementById('math')
 );
 


### PR DESCRIPTION
For me

```
<TeX math="\\int_0^\\infty x^2 dx" />
```

Results in an error:

![image](https://user-images.githubusercontent.com/880132/94613830-1cb9ed00-029d-11eb-8c85-fbe00fd9c80a.png)

There could be other instances in the file that needs fixing, but wasn't sure.